### PR TITLE
fix(mise): workaround npm backend timeout issue

### DIFF
--- a/dot_config/mise/config.toml
+++ b/dot_config/mise/config.toml
@@ -22,10 +22,10 @@ legacy_version_file = true
 # Default tool versions (can be overridden per-project with .mise.toml)
 # Uncomment and adjust versions as needed after initial setup
 
-# node = "lts"
+node = "lts"
 # python = "3.12"
 # ruby = "3.3"
 
-# Global npm packages (managed via npm backend)
-"npm:pnpm" = "latest"
-"npm:@anthropic-ai/claude-code" = "latest"
+# Global npm packages are installed via `npm install -g` in the install script
+# instead of mise npm backend (workaround for timeout issues)
+# See: https://github.com/jdx/mise/discussions/4652

--- a/run_once_after_install.sh.tmpl
+++ b/run_once_after_install.sh.tmpl
@@ -42,6 +42,24 @@ else
     echo "Warning: mise not found. Install it via 'brew install mise'"
 fi
 
+# -----------------------------------------------------------------------------
+# Install global npm packages
+# Using npm directly instead of mise npm backend (workaround for timeout issues)
+# See: https://github.com/jdx/mise/discussions/4652
+# -----------------------------------------------------------------------------
+if command -v mise &> /dev/null; then
+    echo "Installing global npm packages..."
+    eval "$(mise activate bash)"
+
+    if command -v npm &> /dev/null; then
+        npm install -g pnpm @anthropic-ai/claude-code || {
+            echo "Warning: Failed to install some npm packages"
+        }
+    else
+        echo "Warning: npm not found. Skipping global package installation."
+    fi
+fi
+
 echo "=== Post-install setup complete ==="
 echo ""
 echo "Please restart your shell: exec zsh"


### PR DESCRIPTION
## Summary

- Replace mise npm backend with direct `npm install -g` to fix timeout issues
- Enable `node = "lts"` in mise config

Closes #1

## Changes

### `dot_config/mise/config.toml`
- Remove npm package definitions (`npm:pnpm`, `npm:@anthropic-ai/claude-code`)
- Enable `node = "lts"` (was commented out)
- Add comment explaining the workaround

### `run_once_after_install.sh.tmpl`
- Add new section to install global npm packages via `npm install -g`
- Runs after mise setup to ensure Node.js/npm are available

## Background

mise's npm backend has known timeout issues when running `npm view` internally. This causes:
1. New terminal tabs to hang during shell initialization
2. `mise install` to fail with timeout errors

Manual `npm view` commands work fine, so this is a mise-specific issue.

Related: https://github.com/jdx/mise/discussions/4652

## Test plan

- [ ] Run `chezmoi apply --verbose` on a fresh machine
- [ ] Verify `mise list` shows node but not npm packages
- [ ] Verify `pnpm -v` and `claude --version` work
- [ ] Verify new terminal tabs open without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)